### PR TITLE
Add status watcher for bayeux client

### DIFF
--- a/bayeux.go
+++ b/bayeux.go
@@ -114,14 +114,14 @@ func (b *Bayeux) GetConnectedCount() int {
 }
 
 type Client struct {
-	BayOb Bayeux
+	Bay Bayeux // Bayeux for client
 }
 
 func NewClient() Client {
 	client := Client{}
 	b := Bayeux{}
 	client = Client{
-		BayOb: b,
+		Bay: b,
 	}
 	return client
 }


### PR DESCRIPTION
- Add client to watch over status of subscriptions. To check how many connections bayeux instance has.
- Make sure to close channel as soon as context is canceled to ensure it won't hold channel open for forever.
